### PR TITLE
make clippy forbid unwrap and expect

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -46,5 +46,5 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          args: --all-features -- --forbid expect_used --forbid unwrap_used
           name: Clippy Output


### PR DESCRIPTION
This PR forces proper error handling by not allowing unwrap or expect to be used. This has not been tested, as it is a change to the GH Actions workflow. This PR serves as the test.